### PR TITLE
Add trash objects endpoint and related logic

### DIFF
--- a/src/SF.PhotoPixels.API/Endpoints/PhotosEndpoints/TrashObjects.cs
+++ b/src/SF.PhotoPixels.API/Endpoints/PhotosEndpoints/TrashObjects.cs
@@ -1,0 +1,37 @@
+using Ardalis.ApiEndpoints;
+using Mediator;
+using Microsoft.AspNetCore.Mvc;
+using SF.PhotoPixels.Application.Commands.ObjectVersioning;
+using SF.PhotoPixels.Application.Commands.ObjectVersioning.TrashObject;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace SF.PhotoPixels.API.Endpoints.PhotosEndpoints;
+
+public class TrashObjects : EndpointBaseAsync
+    .WithRequest<TrashObjectsRequest>
+    .WithActionResult<ObjectVersioningResponse>
+{
+    private readonly IMediator _mediator;
+
+    public TrashObjects(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpPost("/object/trash")]
+    [SwaggerOperation(
+            Summary = "Trash objects",
+            Description = "Trash objects to the server")
+    ]
+    public override async Task<ActionResult<ObjectVersioningResponse>> HandleAsync([FromBody] TrashObjectsRequest trashObjectsRequest, CancellationToken cancellationToken = default)
+    {
+       // var trashObjectsRequest = new TrashObjectsRequest { ObjectIds = new List<string>() };
+
+        var result = await _mediator.Send(trashObjectsRequest, cancellationToken);
+
+        return result.Match<ActionResult<ObjectVersioningResponse>>(
+            response => new OkObjectResult(response),
+            _ => new NotFoundResult()
+        );
+    }
+}

--- a/src/SF.PhotoPixels.Application/Commands/ObjectVersioning/TrashObject/TrashObjectsHandler.cs
+++ b/src/SF.PhotoPixels.Application/Commands/ObjectVersioning/TrashObject/TrashObjectsHandler.cs
@@ -1,0 +1,59 @@
+using Marten;
+using Mediator;
+using OneOf.Types;
+using SF.PhotoPixels.Application.Commands.ObjectVersioning.TrashObject;
+using SF.PhotoPixels.Application.Core;
+using SF.PhotoPixels.Domain.Entities;
+using SF.PhotoPixels.Domain.Events;
+using SF.PhotoPixels.Infrastructure.Repositories;
+
+namespace SF.PhotoPixels.Application.Commands.ObjectVersioning.DeleteObject;
+
+public class TrashObjectsHandler : IRequestHandler<TrashObjectsRequest, ObjectVersioningResponse>
+{
+    private readonly IExecutionContextAccessor _executionContextAccessor;
+    private readonly IObjectRepository _objectRepository;
+    private readonly IDocumentSession _session;
+
+    public TrashObjectsHandler(IExecutionContextAccessor executionContextAccessor, IObjectRepository objectRepository, IDocumentSession session)
+    {
+        _executionContextAccessor = executionContextAccessor;
+        _objectRepository = objectRepository;
+        _session = session;
+    }
+
+    public async ValueTask<ObjectVersioningResponse> Handle(TrashObjectsRequest request, CancellationToken cancellationToken)
+    {
+        var objectsMetadata = await _session.Query<ObjectProperties>()
+            .Where(objects => request.ObjectIds.Contains(objects.Id)).ToListAsync(cancellationToken);
+
+        if (!objectsMetadata.Any())
+        {
+            return new NotFound();
+        }
+
+        var user = await _session.LoadAsync<Domain.Entities.User>(_executionContextAccessor.UserId);
+        if (user == null)
+        {
+            return new NotFound();
+        }
+
+        _session.DeleteObjects(objectsMetadata);
+        await _session.SaveChangesAsync();
+
+        long revision = 0;
+        foreach (var objectMetadata in objectsMetadata)
+        {
+            revision = await _objectRepository.AddEvent(
+                _executionContextAccessor.UserId,
+                new MediaObjectTrashed(objectMetadata.Id, DateTimeOffset.UtcNow),
+                cancellationToken
+            );
+        }
+
+        return new VersioningResponse
+        {
+            Revision = revision
+        };
+    }
+}

--- a/src/SF.PhotoPixels.Application/Commands/ObjectVersioning/TrashObject/TrashObjectsRequest.cs
+++ b/src/SF.PhotoPixels.Application/Commands/ObjectVersioning/TrashObject/TrashObjectsRequest.cs
@@ -1,0 +1,8 @@
+using Mediator;
+
+namespace SF.PhotoPixels.Application.Commands.ObjectVersioning.TrashObject;
+
+public class TrashObjectsRequest : IRequest<ObjectVersioningResponse>
+{
+    public required List<string> ObjectIds { get; set; }
+}

--- a/src/SF.PhotoPixels.Infrastructure/Services/VideoService/VideoService.cs
+++ b/src/SF.PhotoPixels.Infrastructure/Services/VideoService/VideoService.cs
@@ -43,11 +43,11 @@ public class VideoService : IVideoService
         var evt = new MediaObjectCreated
         {
             ObjectId = objectId,
-            Extension = video.GetExtension(filename),
+            Extension = extension,
             MimeType = video.GetMimeType(extension),
             Height = video.Height,
             Width = video.Width,
-            Name = video.GetName(filename),
+            Name = filename,
             Timestamp = new DateTimeOffset(video.GetDateTime()).ToUnixTimeMilliseconds(),
             Hash = fingerprint,
             OriginalHash = hash,


### PR DESCRIPTION
#82 
Introduces a new API endpoint for trashing objects at "/object/trash" in `TrashObjects.cs`, utilizing the Mediator pattern for request handling. Updates `TrashObjectsHandler.cs` to implement the logic for querying object metadata, user validation, and event logging for trashed objects. Defines a request model in `TrashObjectsRequest.cs` for specifying object IDs. Also refactors `VideoService.cs` to use a variable for the file extension when creating a `MediaObjectCreated` event.